### PR TITLE
Change the settings page identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Version [2.2.2]
+
+### Chore
+
+-   Change the settings page identifier to prevent collision with OpenPDC
+
 ## Version [2.2.1]
 
 ### Feat

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'base'          => [
+    'pub_base'          => [
         'id'             => 'general',
         'title'          => _x('Portal', 'OpenPub instellingen subpagina', 'openpub-base'),
         'settings_pages' => '_owc_openpub_base_settings',

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'pub_base'          => [
+    'openpub_base'          => [
         'id'             => 'general',
         'title'          => _x('Portal', 'OpenPub instellingen subpagina', 'openpub-base'),
         'settings_pages' => '_owc_openpub_base_settings',

--- a/openpub-base.php
+++ b/openpub-base.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Yard | OpenPub Base
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Acts as foundation for other OpenPub related content plugins. This plugin implements actions to allow for other plugins to add and/or change Custom Posttypes, Metaboxes, Taxonomies, en Posts 2 posts relations.
- * Version:           2.2.1
+ * Version:           2.2.2
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0

--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -24,7 +24,7 @@ class Plugin
      *
      * @var string VERSION
      */
-    public const VERSION = '2.2.1';
+    public const VERSION = '2.2.2';
 
     /**
      * Path to the root of the plugin.


### PR DESCRIPTION
In our setup the OpenPUB and OpenPDC plugins are installed within the same WordPress installation. This is causing an issue with displaying the OpenPUB settings page, as both the OpenPDC and OpenPUB use the identifier `base`. 

https://github.com/OpenWebconcept/plugin-openpub-base/blob/9877217ba70d773a9e1be5207365f71b1e0d9a8b/config/settings.php#L4

This PR changes the identifier to `pub_base`.