### PR TITLE
Add filter to add geodata to REST API from OpenKaarten Geodata plugin

### DIFF
--- a/src/Base/Repositories/AbstractRepository.php
+++ b/src/Base/Repositories/AbstractRepository.php
@@ -235,7 +235,7 @@ abstract class AbstractRepository
             'post_status' => $post->post_status
         ];
 
-		$data = apply_filters( 'ok_geo_rest_add_geodata', $data, $post );
+		$data = apply_filters( 'owc/openkaarten/geodata/rest-add-fields', $data, $post );
 
 		$data = $this->assignFields($data, $post);
 

--- a/src/Base/Repositories/AbstractRepository.php
+++ b/src/Base/Repositories/AbstractRepository.php
@@ -235,7 +235,9 @@ abstract class AbstractRepository
             'post_status' => $post->post_status
         ];
 
-        $data = $this->assignFields($data, $post);
+		$data = apply_filters( 'ok_geo_rest_add_geodata', $data, $post );
+
+		$data = $this->assignFields($data, $post);
 
         return $data;
     }


### PR DESCRIPTION
Via the OpenKaarten Geodata plugin (which will be released shortly) you can add Geodata fields to post types, for example the OpenPub Items. Via this added filter the geodata will be added to the OpenPub REST API endpoint wp-json/owc/openpub/v1/items/active as a geometry object.