### PR TITLE
(fix): Notice: Function _load_textdomain_just_in_time was called inco…

### DIFF
--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -47,7 +47,6 @@ class Plugin
 	public function __construct(string $rootPath)
 	{
 		$this->rootPath = $rootPath;
-		\load_plugin_textdomain($this->getName(), false, $this->getName() . '/languages/');
 
 		$this->loader = new Loader();
 
@@ -95,6 +94,7 @@ class Plugin
 
 		// Register the Hook loader.
 		$this->loader->addAction('init', $this, 'filterPlugin', 4);
+		$this->loader->addAction('after_setup_theme', $this, 'loadTextDomain', 4);
 		$this->loader->register();
 
 		return true;
@@ -136,6 +136,14 @@ class Plugin
 	public function filterPlugin(): void
 	{
 		\do_action('owc/' . self::NAME . '/plugin', $this);
+	}
+
+	/**
+	 * Load the plugin textdomain.
+	 */
+	public function loadTextDomain(): void
+	{
+		\load_plugin_textdomain($this->getName(), false, $this->getName() . '/languages/');
 	}
 
 	/**


### PR DESCRIPTION
…rrectly.

Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the openpub-base domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. 

**Also fixes openpub-internal-data:**

Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the openpub-internal-data domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later.