### PR TITLE
(feat): add taxonomies to the api added through apply_filter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.7.6
+
+- Feat: add taxonomies to API added through apply_filter
+
 ## v3.7.5
 
 - Feat: add author id in API response of items endpoint

--- a/openpub-base.php
+++ b/openpub-base.php
@@ -4,7 +4,7 @@
  * Plugin Name:       Yard | OpenPub Base
  * Plugin URI:        https://www.openwebconcept.nl/
  * Description:       Acts as foundation for other OpenPub related content plugins. This plugin implements actions to allow for other plugins to add and/or change Custom Posttypes, Metaboxes, Taxonomies, en Posts 2 posts relations.
- * Version:           3.7.5
+ * Version:           3.7.6
  * Author:            Yard | Digital Agency
  * Author URI:        https://www.yard.nl/
  * License:           GPL-3.0

--- a/src/Base/Foundation/Plugin.php
+++ b/src/Base/Foundation/Plugin.php
@@ -8,7 +8,7 @@ use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 class Plugin
 {
     public const NAME = 'openpub-base';
-    public const VERSION = '3.7.5';
+    public const VERSION = '3.7.6';
 
     protected string $rootPath;
     public Config $config;

--- a/src/Base/RestAPI/ItemFields/TaxonomyField.php
+++ b/src/Base/RestAPI/ItemFields/TaxonomyField.php
@@ -12,9 +12,17 @@ class TaxonomyField extends CreatesFields
      */
     public function create(WP_Post $post): array
     {
-        $result = [];
+    	$result = [];
 
-        foreach (array_keys($this->plugin->config->get('taxonomies')) as $taxonomy) {
+	    $taxonomies = apply_filters('owc/openpub-base/before-register-extended-taxonomies', $this->plugin->config->get('taxonomies'));
+
+        if (! is_array($taxonomies) || 1 > count($taxonomies)) {
+          return $result;
+	    }
+
+	    $taxonomiesKeys = array_unique(array_keys($taxonomies));
+
+        foreach ($taxonomiesKeys as $taxonomy) {
             $result[$taxonomy] = $this->getTerms($post->ID, $taxonomy);
         }
 


### PR DESCRIPTION
Simon had [hier toegevoegd](https://github.com/OpenWebconcept/plugin-openpub-base/commit/0700dd20fba06913146e46eed38dab67ba7bd32d) dat je taxonomieën kon toevoegen aan de OpenPub items. Deze werden echter niet aan de API meegegeven. Dit voegt het wel toe. 

Kan qua code style wellicht wat beter, ik hoor het graag. 