### PR TITLE
(fix) Moved settings screen under wordpress settings

### DIFF
--- a/config/cmb2_settings_pages.php
+++ b/config/cmb2_settings_pages.php
@@ -6,10 +6,10 @@ return [
         'title'        => __('OpenPub settings', 'openpub-base'),
         'object_types' => ['options-page'],
         'option_key'   => '_owc_openpub_base_settings',
+        'parent_slug'  => 'options-general.php',
+        'menu_title'   => __('OpenPub', 'openpub-base'),
         'tab_group'    => 'base',
         'tab_title'    => __('General', 'openpub-base'),
-        'position'     => 30,
-        'icon_url'    => 'dashicons-admin-settings',
         'fields'       => [
             'portal_url'        => [
                 'name' => __('Portal URL', 'openpub-base'),


### PR DESCRIPTION
The open pub settings screen shows up under my main sidebar while it's a settings screen. It should probably be placed under the settings tab.

So

<img width="265" height="381" alt="Scherm­afbeelding 2026-02-20 om 12 52 21" src="https://github.com/user-attachments/assets/226bf145-a941-4e7c-bec8-55d346a8eb7e" />

Instead of 
<img width="248" height="323" alt="Scherm­afbeelding 2026-02-20 om 12 53 14" src="https://github.com/user-attachments/assets/4e186f64-0f67-4962-b44c-ed62db2052c7" />
